### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ How can you add your tool? via a pull request, if you dont know what that is, re
 - [bigsnpr](https://github.com/privefl/bigsnpr) R package for the analysis of massive SNP arrays, primarily designed for human genetics.
 - [ukbrapR](https://github.com/lcpilling/ukbrapR) ukbrapR (phonetically: 'U-K-B-wrapper') is an R package for working in the UK Biobank Research Analysis Platform (RAP). The aim is to make it quicker, easier, and more reproducible.
 - [MungeSumstats](https://github.com/Al-Murphy/MungeSumstats) R package designed to facilitate the standardisation of GWAS summary statistics.
+- [gwasRtools](https://github.com/lcpilling/gwasRtools) R package to (1) identify loci and independent lead SNPs (using online or local reference panel) and (2) annotate variants with nearest gene from GENCODE database.


### PR DESCRIPTION
Little R package to identify loci and lead SNPs from GWAS summary stats. It's pretty flexible - objective was to just make my life easier for these repetitive tasks! 

Can do "simple" distance based lead SNP identification, or with the `ld_clump` option can use an LD panel utilizing `ieugwasr::ld_clump()` (online via their API, or locally with Plink and a custom reference panel). It can then annotate the output with nearest gene from GENCODE (using `snpsettest::map_snp_to_gene()`).

The functions automatically detect common formats (GWAS catalog, REGENIE, etc) -- so it is as simple as:

``` r
# load any GWAS file
gwas <- readr::read_tsv("gwas_catalog_sumstats.tsv")

# find loci and lead SNPs -- let's use a local reference panel
gwas_loci <- gwasRtools::get_loci(gwas, ld_clump=TRUE, ld_bfile="/path/to/plink_files")

# annotate with nearest gene
gwas_loci_genes <- gwasRtools::get_nearest_gene(gwas_loci, build=38)

# see independent lead SNPs with nearest genes
gwas_loci_genes[ gwas_loci_genes$lead==TRUE , ]
```

Lots of customisation possible (e.g., p-value threshold for significant variants, distance for loci, distance to nearest gene, etc). Docs https://lcpilling.github.io/gwasRtools