### PR TITLE
GWAS-VCF

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ How can you add your tool? via a pull request, if you dont know what that is, re
 
 - [bcftools](https://samtools.github.io/bcftools/bcftools.html) bcftools is a tool for creating, editing, and manipulating VCF and BCF files
 
+- [gwas2vcf](https://github.com/MRCIEU/gwas2vcf) Converts GWAS summary statistics to VCF.
+
+- [score](https://github.com/freeseek/score) bcftools plugins for working with GWAS-VCF summary statistics files (munging, liftover, meta-analysis, polygenic scoring, BLUP)
+
 - [GenomicRanges](https://bioconductor.org/packages/release/bioc/html/GenomicRanges.html) An R packages for working with genomic intervals
 
 - [bedtools](https://bedtools.readthedocs.io/en/latest/) Collectively, the bedtools utilities are a swiss-army knife of tools for a wide-range of genomics analysis tasks. A very fast and easy way to intersect, merge, count, complement, and shuffle genomic intervals from multiple files in widely-used genomic file formats such as BAM, BED, GFF/GTF, VCF


### PR DESCRIPTION
Convert sumstats to VCF (gwas2vcf) and work with them using bcftools (score plugins).